### PR TITLE
Add preprocess_image_tensor func for model training usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,17 @@ Apply necessary preprocessing to the input image.
 - Return:
   - NumPy array of shape `(224, 224, 3)`.
 
+### `preprocess_image_tensor`
+Tensor-based preprocessing equivalent of `preprocess_image`, suitable for use with
+dataset pipelines (e.g., `tf.data.Dataset.map`).
+Note that the JPEG round-trip in the `YAHOO` pipeline is intentionally omitted.
+- Parameters:
+  - `image` (Keras tensor of shape `(H, W, C)`, `uint8`): Input as a single RGB image tensor.
+  - `preprocessing` (`Preprocessing` enum, default `Preprocessing.YAHOO`):
+    See [preprocessing details](#preprocessing-details).
+- Return:
+  - Keras tensor of shape `(224, 224, 3)`.
+
 ### `Preprocessing`
 Enum class for preprocessing options.
 - `Preprocessing.YAHOO`

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ elapsed_seconds, nsfw_probabilities = n2.predict_video_frames(video_path)
 
 ## Lower level with Keras
 
+### Inference
+
 ```python
 import numpy as np
 import opennsfw2 as n2
@@ -120,6 +122,52 @@ predictions = model.predict(inputs)
 # Each row gives [sfw_probability, nsfw_probability] of an input image, e.g.:
 sfw_probability, nsfw_probability = predictions[0]
 ```
+
+### Training / Fine-tuning with TensorFlow backend
+
+```python
+import opennsfw2 as n2
+import tensorflow as tf
+
+# Prepare a list of image file paths and corresponding labels.
+# Labels: 0 for SFW, 1 for NSFW.
+image_paths = [
+  "path/to/your/image1.jpg",
+  "path/to/your/image2.jpg",
+  # ...
+]
+labels = [0, 1, ...]
+
+# Build a tf.data pipeline with per-sample preprocessing.
+dataset = tf.data.Dataset.from_tensor_slices((image_paths, labels))
+
+def load_and_preprocess(image_path, label):
+  image = tf.io.read_file(image_path)
+  image = tf.io.decode_jpeg(image, channels=3)
+  # The preprocessed image is a tensor of shape (224, 224, 3).
+  image = n2.preprocess_image_tensor(image, n2.Preprocessing.YAHOO)
+  return image, label
+
+dataset = (
+  dataset
+  .map(load_and_preprocess, num_parallel_calls=tf.data.AUTOTUNE)
+  .batch(32)
+  .prefetch(tf.data.AUTOTUNE)
+)
+
+# For fine-tuning, load the pre-trained weights (default behaviour).
+# For training from scratch, pass weights_path=None.
+model = n2.make_open_nsfw_model()
+
+# Compile and train.
+model.compile(
+  optimizer="adam",
+  loss="sparse_categorical_crossentropy",
+  metrics=["accuracy"],
+)
+model.fit(dataset, epochs=10)
+```
+
 
 # API
 

--- a/opennsfw2/__init__.py
+++ b/opennsfw2/__init__.py
@@ -1,6 +1,7 @@
 # See: https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport
 from ._image import Preprocessing as Preprocessing
 from ._image import preprocess_image as preprocess_image
+from ._image import preprocess_image_tensor as preprocess_image_tensor
 from ._inference import Aggregation
 from ._inference import predict_image as predict_image
 from ._inference import predict_images as predict_images

--- a/opennsfw2/_image.py
+++ b/opennsfw2/_image.py
@@ -4,11 +4,12 @@ Image utilities.
 import io
 from enum import Enum
 
+import keras  # type: ignore
 import numpy as np
 import skimage.io  # type: ignore
 from PIL import Image  # type: ignore
 
-from ._typing import NDFloat32Array
+from ._typing import KerasTensor, NDFloat32Array
 
 
 class Preprocessing(str, Enum):
@@ -63,3 +64,32 @@ def preprocess_image(
     image = image - np.array(vgg_mean, dtype=np.float32)
 
     return image
+
+
+def preprocess_image_tensor(
+        image: KerasTensor,
+        preprocessing: Preprocessing = Preprocessing.YAHOO
+) -> KerasTensor:
+    """
+    Tensor-based preprocessing equivalent of `preprocess_image`, suitable
+    for use with dataset pipelines (e.g., tf.data.Dataset.map).
+
+    Expects a single uint8 tensor of shape (H, W, C) in RGB channel order.
+    The JPEG round-trip from the YAHOO pipeline is intentionally omitted.
+    """
+    image = keras.ops.cast(image, "float32")
+
+    if preprocessing == Preprocessing.YAHOO:
+        image = keras.ops.image.resize(image, (256, 256), interpolation="bilinear")
+        h_off = (256 - 224) // 2
+        w_off = (256 - 224) // 2
+        image = image[h_off:h_off + 224, w_off:w_off + 224, :]
+
+    elif preprocessing == Preprocessing.SIMPLE:
+        image = keras.ops.image.resize(image, (224, 224), interpolation="bilinear")
+
+    # RGB to BGR.
+    image = image[..., ::-1]
+
+    vgg_mean = keras.ops.cast([104, 117, 123], "float32")
+    return image - vgg_mean

--- a/opennsfw2/_image.py
+++ b/opennsfw2/_image.py
@@ -83,13 +83,13 @@ def preprocess_image_tensor(
         image = keras.ops.image.resize(image, (256, 256), interpolation="bilinear")
         h_off = (256 - 224) // 2
         w_off = (256 - 224) // 2
-        image = image[h_off:h_off + 224, w_off:w_off + 224, :]
+        image = image[h_off:h_off + 224, w_off:w_off + 224, :]  # type: ignore
 
     elif preprocessing == Preprocessing.SIMPLE:
         image = keras.ops.image.resize(image, (224, 224), interpolation="bilinear")
 
     # RGB to BGR.
-    image = image[..., ::-1]
+    image = image[..., ::-1]  # type: ignore
 
     vgg_mean = keras.ops.cast([104, 117, 123], "float32")
-    return image - vgg_mean
+    return image - vgg_mean  # type: ignore

--- a/opennsfw2/_image.py
+++ b/opennsfw2/_image.py
@@ -35,6 +35,8 @@ def preprocess_image(
             (256, 256), resample=Image.BILINEAR  # pylint: disable=no-member
         )
 
+        # This step, migrated from the original TF1 version, is probably for introducing
+        # JPEG compression artifacts to match the original Caffe data pipeline.
         fh_im = io.BytesIO()
         pil_image_resized.save(fh_im, format="JPEG")
         fh_im.seek(0)
@@ -75,7 +77,10 @@ def preprocess_image_tensor(
     for use with dataset pipelines (e.g., tf.data.Dataset.map).
 
     Expects a single uint8 tensor of shape (H, W, C) in RGB channel order.
-    The JPEG round-trip from the YAHOO pipeline is intentionally omitted.
+
+    The JPEG round-trip from the YAHOO pipeline is intentionally omitted,
+    because this is a lossy and non-differentiable step that makes no sense
+    in training.
     """
     image = keras.ops.cast(image, "float32")
 


### PR DESCRIPTION
- Added `preprocess_image_tensor` to `_image.py`, a tensor-based preprocessing function for use in training pipelines                                                    
- Exported it from `__init__.py`
- Documented it in the API section of `README.md`